### PR TITLE
Add debug logging for content comparison

### DIFF
--- a/action/generate-deploy-note.js
+++ b/action/generate-deploy-note.js
@@ -305,6 +305,8 @@ async function saveAndCommitDeployNote(prNumber, content, context) {
     }
 
     // If content is the same, no need to commit
+    console.log("DEBUG: currentContent:", currentContent);
+    console.log("DEBUG: content:", content);
     if (currentContent === content && currentContent !== "") {
       console.log("Deploy note content unchanged, exiting without commit");
       return;


### PR DESCRIPTION
## Summary
- Added debug console.log statements for `currentContent` and `content` variables before the comparison at line 310
- This will help identify why the content comparison clause is running frequently even when it shouldn't

## Changes
- Added two debug logs in `action/generate-deploy-note.js` at lines 308-309 to log both variables being compared

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added debug logs to show the values of currentContent and content before comparing them in generate-deploy-note.js. This helps track why the content comparison runs more often than expected.

<!-- End of auto-generated description by cubic. -->

